### PR TITLE
Правки цепочки вызова getElementRawData

### DIFF
--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -72,9 +72,9 @@ class Indexer
     /**
      * @throws Exception
      */
-    public function getElementRawData(_CIBElement $element): array
+    public function getElementRawData(_CIBElement $element, array $skipProps = []): array
     {
-        return $this->keeper->getElementRawData($element);
+        return $this->keeper->getElementRawData($element, $skipProps);
     }
 
     /**

--- a/src/Keeper.php
+++ b/src/Keeper.php
@@ -22,7 +22,7 @@ class Keeper
         $this->elastic = $elastic;
     }
 
-    public function getElementRawData(_CIBElement $element, $skipProps = []): array
+    public function getElementRawData(_CIBElement $element, array $skipProps = []): array
     {
         $data = [];
 


### PR DESCRIPTION
Привел метод getElementRawData класса Indexer в соответствии с методом getElementRawData класса Keeper - добавил прокидывание $skipProps.