### PR TITLE
Доработка реализации метода put класса Keeper (логика update). 

### DIFF
--- a/src/Keeper.php
+++ b/src/Keeper.php
@@ -155,8 +155,9 @@ class Keeper
             'type' => '_doc',
             'body' => [
                 'doc' => $data,
-                'upsert' => $data
-            ]
+                'doc_as_upsert' => true,
+            ],
+            'retry_on_conflict' => 3,
         ];
 
         $response = $this->elastic->update($params);


### PR DESCRIPTION
Доработка реализации метода put класса Keeper (логика update). 
Добавил:
- Параметр update retry_on_conflict = 3. 
Совершаем 3 попытки обновления в случае возникновения конфликта.

- Параметр doc_as_upsert в разделе body.
Вместо повторной передачи массива данных в параметре upsert используем указанный параметр.